### PR TITLE
Διόρθωση μερικών λαθών στον test client

### DIFF
--- a/src/main/groovy/gr/ntua/ece/softeng18b/client/model/ShopList.groovy
+++ b/src/main/groovy/gr/ntua/ece/softeng18b/client/model/ShopList.groovy
@@ -1,6 +1,8 @@
 package gr.ntua.ece.softeng18b.client.model
 
-class ShopList extends Paging {
+import groovy.transform.Canonical 
+
+@Canonical class ShopList extends Paging {
     
     List<Shop> shops
     

--- a/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/JsonRestCallResult.groovy
+++ b/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/JsonRestCallResult.groovy
@@ -69,7 +69,7 @@ class JsonRestCallResult implements RestCallResult {
         int start  = json['start'] as Integer
         int count  = json['count'] as Integer
         long total = json['total'] as Long        
-        def shops  = json['products']
+        def shops  = json['shops']
         List<Shop> shopList = shops.collect { s ->
             parseShop(s)
         }

--- a/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/LowLevelAPI.groovy
+++ b/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/LowLevelAPI.groovy
@@ -5,46 +5,47 @@ import gr.ntua.ece.softeng18b.client.model.Shop
 import org.apache.http.client.fluent.Executor
 import org.apache.http.client.fluent.Form
 import org.apache.http.client.fluent.Request
+import java.nio.charset.Charset
 
 import java.text.SimpleDateFormat
 
 class LowLevelAPI {
-    
+
     static final def SORT_OPTIONS = [
         "id|ASC",
         "id|DESC",
         "name|ASC",
         "name|DESC"
     ]
-    
+
     static final def STATUSES = [
         "ACTIVE",
         "WITHDRAWN",
         "ALL"
     ]
-    
-    static final String DEFAULT_SORT   = SORT_OPTIONS[0]    
+
+    static final String DEFAULT_SORT   = SORT_OPTIONS[0]
     static final String DEFAULT_STATUS = STATUSES[0]
-	
+
     static final String BASE_PATH = "/observatory/api"
     static final String HEADER    = "X-OBSERVATORY-AUTH"
 
     static final String IGNORE_SSL_ERRORS_SYSTEM_PROPERTY = "IGNORE_SSL_ERRORS"
 
     static final SimpleDateFormat FORMAT = new SimpleDateFormat("YYYY-MM-DD")
-    
+
     private final String host
     private final int port
     private final boolean secure
     private final ClientFactory clientFactory
-    
+
     LowLevelAPI(String host, int port, boolean secure) {
         this.host   = host
         this.port   = port
         this.secure = secure
         this.clientFactory = determineClientFactory()
     }
-    
+
     private String createUrl(String endPoint, RestCallFormat format, Map params = null ) {
         Map queryParams
         if (format == RestCallFormat.JSON) {
@@ -52,7 +53,7 @@ class LowLevelAPI {
         }
         else {
             queryParams = [format: format.getName()]
-        }        
+        }
         if (params) queryParams.putAll(params)
         String queryString
         if  (queryParams) {
@@ -60,16 +61,17 @@ class LowLevelAPI {
         }
         else {
             queryString = ""
-        }             
-        String url = "${secure ? 'https' : 'http'}://$host:$port$BASE_PATH/$endPoint$queryString"        
+        }
+        String url = "${secure ? 'https' : 'http'}://$host:$port$BASE_PATH/$endPoint$queryString"
         //println "Fetching $url"
         return url
     }
 
     protected RestCallResult execute(Request req, RestCallFormat format) {
+        req = req.addHeader('content-type', 'application/x-www-form-urlencoded;charset=UTF-8')
         Executor.newInstance(clientFactory.newClient()).execute(req).handleResponse(new RestResponseHandler(format))
     }
-    
+
     RestCallResult login(String username, String password, RestCallFormat format) {
 
         return execute(
@@ -82,101 +84,101 @@ class LowLevelAPI {
             ),
             format
         )
-    }    
-    
+    }
+
     RestCallResult logout(String token, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         return execute(
             Request.Post(createUrl("logout", format)).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult getProduct(String token, String id, RestCallFormat format) {
-        
+
         def req = Request.Get(createUrl("products/$id", format))
-        
+
         if (token) req.addHeader(HEADER, token)
-        
+
         return execute(req, format)
     }
-    
-    RestCallResult getProducts(String token, int start, int count, String status, String sort, RestCallFormat format) {                  
-        
+
+    RestCallResult getProducts(String token, int start, int count, String status, String sort, RestCallFormat format) {
+
         def req = Request.Get(createUrl("products", format, [
             start : start,
             count : count,
             status: status,
             sort  : sort
         ]))
-                    
-        if (token) req.addHeader(HEADER, token)            
-        
+
+        if (token) req.addHeader(HEADER, token)
+
         return execute(req, format)
     }
-    
+
     RestCallResult postProduct(String token, Product product, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addToForm(form, product)
-        
+
         return execute(
-            Request.Post(createUrl("products", format)).bodyForm(form.build()).addHeader(HEADER, token),
+            Request.Post(createUrl("products", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult putProduct(String token, String id, Product product, RestCallFormat format){
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addToForm(form, product)
-        
+
         return execute(
             Request.Put(createUrl("products/$id", format)).bodyForm(form.build()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult patchProduct(String token, String id, String field, def value, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addFieldToForm(form, field, value)
-        
+
         return execute(
             Request.Patch(createUrl("products/$id", format)).bodyForm(form.build()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult deleteProduct(String token, String id, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         return execute(
             Request.Delete(createUrl("products/$id", format)).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult getShop(String token, String id, RestCallFormat format) {
-        
+
         def req = Request.Get(createUrl("shops/$id", format))
-        
+
         if (token) req.addHeader(HEADER, token)
-        
+
         return execute(req, format)
     }
-            
-    RestCallResult getShops(String token, int start, int count, String status, String sort, RestCallFormat format) {                
-        
+
+    RestCallResult getShops(String token, int start, int count, String status, String sort, RestCallFormat format) {
+
         def req = Request.Get(createUrl("shops", format, [
             start : start,
             count : count,
@@ -185,53 +187,53 @@ class LowLevelAPI {
         ]))
 
         if (token) req.addHeader(HEADER, token)
-        
+
         return execute(req, format)
     }
-    
+
     RestCallResult postShop(String token, Shop shop, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addToForm(form, shop)
-        
+
         return execute(
-            Request.Post(createUrl("shops", format)).bodyForm(form.build()).addHeader(HEADER, token),
+            Request.Post(createUrl("shops", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult putShop(String token, String id, Shop shop, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addToForm(form, shop)
-        
+
         return execute(
             Request.Put(createUrl("shops/$id", format)).bodyForm(form.build()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult patchShop(String token, String id, String field, def value, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         Form form = Form.form()
         addFieldToForm(form, field, value)
-        
+
         return execute(
             Request.Patch(createUrl("shops/$id", format)).bodyForm(form.build()).addHeader(HEADER, token),
             format
         )
     }
-    
+
     RestCallResult deleteShop(String token, String id, RestCallFormat format) {
-        
+
         if (!token) throw new RuntimeException("Empty token")
-        
+
         return execute(
             Request.Delete(createUrl("shops/$id", format)).addHeader(HEADER, token),
             format
@@ -257,7 +259,7 @@ class LowLevelAPI {
         addFieldToForm(form, "shopId", shopId)
 
         return execute(
-            Request.Post(createUrl("prices", format)).bodyForm(form.build()).addHeader(HEADER, token),
+            Request.Post(createUrl("prices", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
             format
         )
 
@@ -297,15 +299,15 @@ class LowLevelAPI {
             format
         )
     }
-        
-    private static void addToForm(Form form, def item) {               
+
+    private static void addToForm(Form form, def item) {
         item.class.declaredFields.each {
             if (!it.synthetic) {
                 addFieldToForm(form, it.name, item[(it.name)])
             }
         }
-    }        
-    
+    }
+
     private static void addFieldToForm(Form form, String field, def value) {
         if (value != null) {
             if (value instanceof List) {
@@ -318,23 +320,23 @@ class LowLevelAPI {
             }
         }
     }
-    
+
     private static String encodeForm(Form form) {
-        def list = form.build()                
+        def list = form.build()
         def p = list.collect {
             return it.getName() + "=" + URLEncoder.encode(it.getValue(), 'UTF-8')
         }
-        return p.join("&")                
+        return p.join("&")
     }
-    
-    static String encode(Map params) {        
+
+    static String encode(Map params) {
         Form form = Form.form()
         params.each { k, v ->
             addFieldToForm(form, k, v)
         }
         return encodeForm(form)
-    }        
-    
+    }
+
     static String encode(Object o) {
         Form form = Form.form()
         addToForm(form, o)

--- a/src/test/groovy/gr/ntua/ece/softeng18b/client/ObservatoryAPIFunctionalTest.groovy
+++ b/src/test/groovy/gr/ntua/ece/softeng18b/client/ObservatoryAPIFunctionalTest.groovy
@@ -63,7 +63,7 @@ class ObservatoryAPIFunctionalTest extends Specification {
         returned.name == posted.name &&
         returned.description == posted.description
         returned.category == posted.category &&
-        returned.tags == posted.tags &&
+        returned.tags.toSorted() == posted.tags.toSorted() &&
         !returned.withdrawn
 
         where:
@@ -109,7 +109,7 @@ class ObservatoryAPIFunctionalTest extends Specification {
         returned.address == posted.address &&
         returned.lat == posted.lat &&
         returned.lng == posted.lng &&
-        returned.tags == posted.tags &&
+        returned.tags.toSorted() == posted.tags.toSorted() &&
         !returned.withdrawn
 
         where:

--- a/test-data.json
+++ b/test-data.json
@@ -61,7 +61,7 @@
       "shopIndexes": [0, 1, 2],
       "productIndexes": [0],
       "tags": null,
-      "sort": "price|ASC",
+      "sort": ["price|ASC"],
       "results": {
         "start": 0,
         "count": 10,


### PR DESCRIPTION
* Το `getShopList()` δεν έπαιρνε τα αποτελέσματα του API, καθώς τα
έψαχνε λανθασμένα στο πεδίο `products` της απαντήσης, αντί για το `shops`
* To `model.ShopList` έγινε Canonical class, όπως είναι και το
`model.ProductList`
* Ο έλεγχος ισότητας των tags γίνεται αφού οι λίστες που συγκρίνονται
ταξινομηθούν, ώστε να να μην εμφανίζεται σφάλμα όταν το API γυρνάει τα
tags με διαφορετική σειρά.
* Στα `postProduct`, `postPrice`, `postShop` δίνεται ορίζεται επιπλέον
και το charset των δεδομένων (στο defaultCharset() -> UTF-8).
Διαφορετικά, τα δεδομένα του αιτήματος έρχονται στον server ως σκουπίδια
* Σε όλα τα αιτήματα ορίζεται ρητά το header Content-Type, δηλώνοντας τη
μορφή των δεδομένων και το charset.

Επιπλέον αλλαγές που θα θέλαμε να γίνουν αλλά δεν είναι απαραίτητες:

* Τα URLs να τελειώνουν σε `/` ,πχ `GET prices/` αντι για `GET prices`
* Να γινονται αποδεκτοι και αλλοι κωδικοι επιστροφης, πχ το `201 resource created`