### PR TITLE
Fix for charset on windows

### DIFF
--- a/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/LowLevelAPI.groovy
+++ b/src/main/groovy/gr/ntua/ece/softeng18b/client/rest/LowLevelAPI.groovy
@@ -127,7 +127,7 @@ class LowLevelAPI {
         addToForm(form, product)
 
         return execute(
-            Request.Post(createUrl("products", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
+            Request.Post(createUrl("products", format)).bodyForm(form.build(), Charset.forName("UTF-8")).addHeader(HEADER, token),
             format
         )
     }
@@ -199,7 +199,7 @@ class LowLevelAPI {
         addToForm(form, shop)
 
         return execute(
-            Request.Post(createUrl("shops", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
+            Request.Post(createUrl("shops", format)).bodyForm(form.build(), Charset.forName("UTF-8")).addHeader(HEADER, token),
             format
         )
     }
@@ -259,7 +259,7 @@ class LowLevelAPI {
         addFieldToForm(form, "shopId", shopId)
 
         return execute(
-            Request.Post(createUrl("prices", format)).bodyForm(form.build(), Charset.defaultCharset()).addHeader(HEADER, token),
+            Request.Post(createUrl("prices", format)).bodyForm(form.build(), Charset.forName("UTF-8")).addHeader(HEADER, token),
             format
         )
 


### PR DESCRIPTION
Στα windows το default charset είναι "windows-1252" και όχι UTF8. Αυτές οι αλλαγές δουλευουν για όλα τα συστήματα αφού απαιτεί να είναι UTF8 